### PR TITLE
rename fix for Tools for MicroProfile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to the MicroProfile Extension Pack will be documented below.
 
 ## 0.1.0
-- Added the [MicroProfile Tools extension](https://marketplace.visualstudio.com/items?itemName=redhat.vscode-microprofile)
+- Added the [Tools for MicroProfile extension](https://marketplace.visualstudio.com/items?itemName=redhat.vscode-microprofile)
 
 ## 0.0.3
 - Added the [Payara Tools extension](https://marketplace.visualstudio.com/items?itemName=Payara.payara-vscode)

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ By installing the MicroProfile Extension Pack, the following extensions are inst
 * [MicroProfile Rest Client Generator](https://marketplace.visualstudio.com/items?itemName=MicroProfile-Community.mp-rest-client-generator-vscode-ext) - Quickly generate a MicroProfile Rest Client interface template from an OpenAPI document.
 
 ### Developing a MicroProfile project
-* [MicroProfile Tools](https://marketplace.visualstudio.com/items?itemName=redhat.vscode-microprofile) - Language support for MicroProfile API and properties via [Language Server for Eclipse MicroProfile](https://github.com/eclipse/lsp4mp).
+* [Tools for MicroProfile](https://marketplace.visualstudio.com/items?itemName=redhat.vscode-microprofile) - Language support for MicroProfile APIs and properties via [Language Server for Eclipse MicroProfile](https://github.com/eclipse/lsp4mp).
 
 ### Development tools for runtimes that support MicroProfile
 * [Open Liberty Tools](https://marketplace.visualstudio.com/items?itemName=Open-Liberty.liberty-dev-vscode-ext) - Support for development with [Open Liberty](https://openliberty.io/).


### PR DESCRIPTION
Rename to "Tools for MicroProfile"
![image](https://user-images.githubusercontent.com/26146482/94313007-f702b000-ff4b-11ea-96f4-e93c9355662c.png)

Signed-off-by: Kathryn Kodama <kathryn.s.kodama@gmail.com>