### PR TITLE
Add overview page to be shown on startup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 *.vsix
-.vscode/**
 out
 node_modules
 .vscode-test/

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ out
 node_modules
 .vscode-test/
 package-lock.json
+.DS_Store

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,18 @@
+{
+	"version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Extension",
+            "type": "extensionHost",
+            "request": "launch",
+            "runtimeExecutable": "${execPath}",
+            "args": [
+                "--extensionDevelopmentPath=${workspaceFolder}"
+            ],
+            "outFiles": [
+                "${workspaceFolder}/out/**/*.js"
+            ],
+            "preLaunchTask": "npm: watch"
+        }
+    ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,35 @@
+// See https://go.microsoft.com/fwlink/?LinkId=733558
+// for the documentation about the tasks.json format
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "type": "npm",
+            "script": "watch",
+            "problemMatcher": {
+                "owner": "typescript",
+                "pattern":[
+                    {
+                        "regexp": "\\[tsl\\] ERROR",
+                        "file": 1,
+                        "location": 2,
+                        "message": 3
+                    }
+                ],
+                "background": {
+                    "activeOnStart": true,
+                    "beginsPattern": "Compilation \\w+ starting…",
+                    "endsPattern": "Compilation\\s+finished"
+                }
+            },
+            "isBackground": true,
+            "presentation": {
+                "reveal": "never"
+            },
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            }
+        }
+    ]
+}

--- a/README.md
+++ b/README.md
@@ -12,10 +12,17 @@ By installing the MicroProfile Extension Pack, the following extensions are inst
 ### Developing a MicroProfile project
 * [Tools for MicroProfile](https://marketplace.visualstudio.com/items?itemName=redhat.vscode-microprofile) - Language support for MicroProfile APIs and properties via [Language Server for Eclipse MicroProfile](https://github.com/eclipse/lsp4mp).
 
+## Other Recommendations
+
 ### Development tools for runtimes that support MicroProfile
 * [Open Liberty Tools](https://marketplace.visualstudio.com/items?itemName=Open-Liberty.liberty-dev-vscode-ext) - Support for development with [Open Liberty](https://openliberty.io/).
 * [Quarkus](https://marketplace.visualstudio.com/items?itemName=redhat.vscode-quarkus) - Support for development with [Quarkus](https://quarkus.io/).
 * [Payara Tools](https://marketplace.visualstudio.com/items?itemName=Payara.payara-vscode) - Support for development with [Payara](https://www.payara.fish/).
 
+## VS Code Settings
+- `microprofile.alwaysShowOverview`: Determines whether to show the overview page on extension startup. Default value is `true`.
+
 ## Contributing
 Do you have a suggestion for the MicroProfile Extension Pack? File an [issue](https://github.com/MicroShed/vscode-microprofile-pack/issues) or submit a pull request if there is an extension that should be added to the extension pack.  Our [CONTRIBUTING](CONTRIBUTING.md) document contains details for submitting pull requests.
+
+MicroProfile® and the MicroProfile logo are trademarks of the Eclipse Foundation

--- a/package.json
+++ b/package.json
@@ -33,12 +33,68 @@
   "bugs": {
     "url": "https://github.com/MicroShed/vscode-microprofile-pack/issues"
   },
+  "main": "./out/extension.js",
+  "activationEvents": [
+    "onStartupFinished",
+    "onLanguage:java",
+    "onCommand:microprofile.overview",
+    "onWebviewPanel:microprofile.overview"
+  ],
+  "contributes": {
+    "commands": [
+      {
+        "command": "microprofile.overview",
+        "category": "MicroProfile",
+        "title": "Overview"
+      }
+    ],
+    "configuration": [
+      {
+        "title": "MicroProfile Extension Pack",
+        "properties": {
+          "microprofile.alwaysShowOverview": {
+            "type": "boolean",
+            "default": true,
+            "description": "Determines whether to show the overview page on startup."
+          }
+        }
+      }
+    ]
+  },
+  "scripts": {
+    "vscode:prepublish": "npm run build",
+    "compile": "webpack --config webpack.config.js",
+    "watch": "webpack --config webpack.config.js --watch --info-verbosity verbose",
+    "build": "webpack --config webpack.config.js --mode=\"production\""
+  },
+  "devDependencies": {
+    "@types/jquery": "^3.5.1",
+    "@types/node": "^14.11.2",
+    "@types/vscode": "1.32.0",
+    "@typescript-eslint/eslint-plugin": "^2.17.0",
+    "@typescript-eslint/parser": "^2.17.0",
+    "autoprefixer": "^8.5.1",
+    "bootstrap": "^4.5.2",
+    "css-loader": "^3.6.0",
+    "eslint": "^6.8.0",
+    "eslint-config-prettier": "^6.9.0",
+    "eslint-plugin-prettier": "^3.1.2",
+    "html-webpack-inline-source-plugin": "0.0.10",
+    "html-webpack-plugin": "^3.2.0",
+    "jquery": "^3.5.1",
+    "node-sass": "^4.14.1",
+    "postcss-loader": "^2.1.5",
+    "prettier": "^1.19.1",
+    "sass-loader": "^7.3.1",
+    "style-loader": "^0.21.0",
+    "ts-loader": "^4.3.0",
+    "typescript": "^3.3.1",
+    "webpack": "^4.44.1",
+    "webpack-cli": "^3.3.12"
+  },
   "extensionPack": [
     "MicroProfile-Community.mp-starter-vscode-ext",
     "MicroProfile-Community.mp-rest-client-generator-vscode-ext",
-    "redhat.vscode-microprofile",
-    "Open-Liberty.liberty-dev-vscode-ext",
-    "redhat.vscode-quarkus",
-    "Payara.payara-vscode"
+    "redhat.vscode-microprofile"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -35,8 +35,10 @@
   },
   "main": "./out/extension.js",
   "activationEvents": [
-    "onStartupFinished",
     "onLanguage:java",
+    "workspaceContains:pom.xml",
+    "workspaceContains:build.gradle",
+    "workspaceContains:mnvw",
     "onCommand:microprofile.overview",
     "onWebviewPanel:microprofile.overview"
   ],

--- a/src/assets/vscode.scss
+++ b/src/assets/vscode.scss
@@ -1,0 +1,44 @@
+/**
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT license.
+ * @see https://github.com/microsoft/vscode-java-pack/blob/master/src/assets/vscode.scss
+ */
+
+$body-bg: var(--vscode-editor-background);
+$body-color: var(--vscode-editor-foreground);
+$link-color: var(--vscode-textLink-foreground) !default;
+$link-hover-color: $link-color;
+$link-hover-decoration: none !default;
+
+$list-group-bg: var(--vscode-notifications-background) !default;
+$list-group-active-color: var(--vscode-notifications-foreground) !default;
+$list-group-active-bg: var(--vscode-notifications-border) !default;
+$list-group-hover-bg: $list-group-bg;
+$list-group-action-active-bg: $list-group-bg;
+$list-group-border-color: var(--vscode-notifications-background) !default;
+$list-group-action-color: var(--vscode-notifications-foreground) !default;
+$list-group-item-padding-y: .75rem !default;
+$list-group-item-padding-x: 1rem !default;
+
+$list-group-border-radius:          0 !default;
+
+$font-size-base: .8rem !default;
+
+$code-font-size: $font-size-base;
+$kbd-bg: var(--vscode-button-background) !default;
+$kbd-color: var(--vscode-button-foreground) !default;
+$pre-color: var(--vscode-textPreformat-foreground) !default;
+
+$text-muted: var(--vscode-editorCodeLens-foreground) !default;
+
+$nav-tabs-link-active-color: var(--vscode-sideBarTitle-foreground);
+$nav-tabs-link-active-bg: var(--vscode-sideBar-background);
+$nav-tabs-link-active-border-color: var(--vscode-sideBarTitle-foreground) var(--vscode-sideBarTitle-foreground) var(--vscode-sideBar-background) var(--vscode-sideBarTitle-foreground);
+$nav-tabs-link-hover-border-color: var(--vscode-sideBarTitle-foreground);
+$nav-tabs-border-color:  var(--vscode-sideBarTitle-foreground);
+
+$card-bg: var(--vscode-sideBar-background);
+$card-color: var(--vscode-sideBarTitle-foreground);
+$card-border-color: var(--vscode-sideBar-border);
+
+@import "~bootstrap/scss/bootstrap";

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,0 +1,48 @@
+import * as vscode from "vscode";
+import { OverviewPage } from "./overview/OverviewPage";
+import { createMicroProfileStarterProjectCmdHandler, generateMicroProfileRESTClient, installExtension, openUrl } from "./util/commands";
+import { MICROPROFILE_SHOW_OVERVIEW_CONFIGURATION } from "./util/constants";
+
+export function activate(context: vscode.ExtensionContext): void {
+  context.subscriptions.push(
+    vscode.commands.registerCommand("microprofile.overview", (async () => {
+      OverviewPage.showOverview(context);
+    }))
+  );
+
+  context.subscriptions.push(
+    vscode.commands.registerCommand("microprofile.helper.createMicroProfileStarterProject", (async () => {
+      createMicroProfileStarterProjectCmdHandler(context);
+    }))
+  );
+
+  context.subscriptions.push(
+    vscode.commands.registerCommand("microprofile.helper.generateMicroProfileRESTClient", (async () => {
+      generateMicroProfileRESTClient(context);
+    }))
+  );
+
+  context.subscriptions.push(
+    vscode.commands.registerCommand("microprofile.helper.openUrl", (async (url) => {
+      openUrl(context, url);
+    }))
+  );
+
+  context.subscriptions.push(
+    vscode.commands.registerCommand("microprofile.helper.installExtension", (async (extensionName) => {
+      installExtension(context, extensionName);
+    }))
+  );
+
+  let showOverviewPage = vscode.workspace.getConfiguration().get<boolean>(MICROPROFILE_SHOW_OVERVIEW_CONFIGURATION);
+  if (showOverviewPage === undefined) {
+    vscode.workspace.getConfiguration().update(MICROPROFILE_SHOW_OVERVIEW_CONFIGURATION, true, vscode.ConfigurationTarget.Global);
+  }
+  if (showOverviewPage) {
+    vscode.commands.executeCommand("microprofile.overview");
+  }
+}
+
+// this method is called when the extension is deactivated
+// eslint-disable-next-line @typescript-eslint/no-empty-function
+export function deactivate(): void { }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -35,9 +35,6 @@ export function activate(context: vscode.ExtensionContext): void {
   );
 
   let showOverviewPage = vscode.workspace.getConfiguration().get<boolean>(MICROPROFILE_SHOW_OVERVIEW_CONFIGURATION);
-  if (showOverviewPage === undefined) {
-    vscode.workspace.getConfiguration().update(MICROPROFILE_SHOW_OVERVIEW_CONFIGURATION, true, vscode.ConfigurationTarget.Global);
-  }
   if (showOverviewPage) {
     vscode.commands.executeCommand("microprofile.overview");
   }

--- a/src/overview/assets/index.html
+++ b/src/overview/assets/index.html
@@ -42,18 +42,16 @@
           <div class="col">
             <h3 class="font-weight-light">Extensions</h3>
             <div ext="redhat.vscode-microprofile" displayName="Tools for MicroProfile by Red Hat">
-              <a href="#" title="Install Tools for MicroProfile extension...">Install Tools for MicroProfile by Red
-                Hat</a>
+              <a href="#" title="Install Tools for MicroProfile extension...">Install Tools for MicroProfile</a>
             </div>
             <div ext="MicroProfile-Community.mp-starter-vscode-ext"
               displayName="MicroProfile Starter by MicroProfile Community">
-              <a href="#" title="Install MicroProfile Starter extension...">Install MicroProfile Starter by MicroProfile
-                Community</a>
+              <a href="#" title="Install MicroProfile Starter extension...">Install MicroProfile Starter</a>
             </div>
             <div ext="MicroProfile-Community.mp-rest-client-generator-vscode-ext"
               displayName="MicroProfile REST Client Generator by MicroProfile Community">
               <a href="#" title="Install MicroProfile REST Client Generator extension...">Install MicroProfile REST
-                Client Generator by MicroProfile Community</a>
+                Client Generator</a>
             </div>
           </div>
         </div>
@@ -62,21 +60,21 @@
             <h3 class="font-weight-light">MicroProfile Runtimes</h3>
             <div>
               <a href="command:microprofile.helper.openUrl?%22https%3A%2F%2Fmarketplace.visualstudio.com%2Fitems%3FitemName%3Dopen-liberty.liberty-dev-vscode-ext%26ssr%3Dfalse%23overview%22"
-                title="Open Liberty Tools marketplace link">Open Liberty Tools for VS Code</a>
+                title="Open Liberty Tools marketplace link">View Open Liberty Tools on the Marketplace</a>
+            </div>
+            <div>
+              <a href="command:microprofile.helper.openUrl?%22https%3A%2F%2Fmarketplace.visualstudio.com%2Fitems%3FitemName%3Dredhat.vscode-quarkus%26ssr%3Dfalse%23overview%22"
+              title="Quarkus Tools marketplace Link">View Quarkus Tools on the Marketplace</a>
+            </div>
+            <div>
+              <a href="command:microprofile.helper.openUrl?%22https%3A%2F%2Fmarketplace.visualstudio.com%2Fitems%3FitemName%3Dpayara.payara-vscode%26ssr%3Dfalse%23overview%22"
+              title="Payara Tools marketplace link">View Payara Tools on the Marketplace</a>
             </div>
             <div ext="Open-Liberty.liberty-dev-vscode-ext" displayName="Open Liberty Tools">
               <a href="#" title="Install Open Liberty Tools extension...">Install Open Liberty Tools</a>
             </div>
-            <div>
-              <a href="command:microprofile.helper.openUrl?%22https%3A%2F%2Fmarketplace.visualstudio.com%2Fitems%3FitemName%3Dredhat.vscode-quarkus%26ssr%3Dfalse%23overview%22"
-              title="Quarkus Tools marketplace Link">Quarkus Tools for VS Code</a>
-            </div>
             <div ext="redhat.vscode-quarkus" displayName="Quarkus Tools">
-              <a href="#" title="Install Quarkus Tools extension...">Install Quarkus Tools</a> 
-            </div>
-            <div>
-              <a href="command:microprofile.helper.openUrl?%22https%3A%2F%2Fmarketplace.visualstudio.com%2Fitems%3FitemName%3Dpayara.payara-vscode%26ssr%3Dfalse%23overview%22"
-              title="Payara Tools marketplace link">Payara Tools for VS Code</a>
+              <a href="#" title="Install Quarkus Tools extension...">Install Quarkus Tools</a>
             </div>
             <div ext="Payara.payara-vscode" displayName="Payara Tools">
               <a href="#" title="Install Payara Tools extension...">Install Payara Tools</a>

--- a/src/overview/assets/index.html
+++ b/src/overview/assets/index.html
@@ -1,0 +1,106 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8">
+  <title>MicroProfile Overview</title>
+</head>
+
+<body>
+  <div class="container mt-5 mb-5">
+    <div class="row mb-3">
+      <div class="col">
+        <h1>MicroProfile Overview</h1>
+      </div>
+    </div>
+    <div class="row">
+      <div class="col">
+        <div class="row mb-3">
+          <div class="col">
+            <h3 class="font-weight-light">Start</h3>
+            <div>
+              <a href="command:microprofile.helper.createMicroProfileStarterProject"
+                title="Create a project with MicroProfile Starter">Create a MicroProfile project...</a>
+            </div>
+            <div>
+              <a href="command:microprofile.helper.generateMicroProfileRESTClient"
+                title="Generate a MicroProfile REST Client with REST Client Generater for MicroProfile">Generate a
+                MicroProfile REST Client interface template...</a>
+            </div>
+          </div>
+        </div>
+        <div class="row mb-3">
+          <div class="col">
+            <h3 class="font-weight-light">Documentation</h3>
+            <div>
+              <a href="command:microprofile.helper.openUrl?%22https%3A%2F%2Fmicroprofile.io%22"
+                title="Learn about MicroProfile">MicroProfile</a>
+            </div>
+          </div>
+        </div>
+        <div class="row mb-3">
+          <div class="col">
+            <h3 class="font-weight-light">Extensions</h3>
+            <div ext="redhat.vscode-microprofile" displayName="Tools for MicroProfile by Red Hat">
+              <a href="#" title="Install Tools for MicroProfile extension...">Install Tools for MicroProfile by Red
+                Hat</a>
+            </div>
+            <div ext="MicroProfile-Community.mp-starter-vscode-ext"
+              displayName="MicroProfile Starter by MicroProfile Community">
+              <a href="#" title="Install MicroProfile Starter extension...">Install MicroProfile Starter by MicroProfile
+                Community</a>
+            </div>
+            <div ext="MicroProfile-Community.mp-rest-client-generator-vscode-ext"
+              displayName="MicroProfile REST Client Generator by MicroProfile Community">
+              <a href="#" title="Install MicroProfile REST Client Generator extension...">Install MicroProfile REST
+                Client Generator by MicroProfile Community</a>
+            </div>
+          </div>
+        </div>
+        <div class="row mb-3">
+          <div class="col">
+            <h3 class="font-weight-light">MicroProfile Runtimes</h3>
+            <div>
+              <a href="command:microprofile.helper.openUrl?%22https%3A%2F%2Fmarketplace.visualstudio.com%2Fitems%3FitemName%3Dopen-liberty.liberty-dev-vscode-ext%26ssr%3Dfalse%23overview%22"
+                title="Open Liberty Tools marketplace link">Open Liberty Tools for VS Code</a>
+            </div>
+            <div ext="Open-Liberty.liberty-dev-vscode-ext" displayName="Open Liberty Tools">
+              <a href="#" title="Install Open Liberty Tools extension...">Install Open Liberty Tools</a>
+            </div>
+            <div>
+              <a href="command:microprofile.helper.openUrl?%22https%3A%2F%2Fmarketplace.visualstudio.com%2Fitems%3FitemName%3Dredhat.vscode-quarkus%26ssr%3Dfalse%23overview%22"
+              title="Quarkus Tools marketplace Link">Quarkus Tools for VS Code</a>
+            </div>
+            <div ext="redhat.vscode-quarkus" displayName="Quarkus Tools">
+              <a href="#" title="Install Quarkus Tools extension...">Install Quarkus Tools</a> 
+            </div>
+            <div>
+              <a href="command:microprofile.helper.openUrl?%22https%3A%2F%2Fmarketplace.visualstudio.com%2Fitems%3FitemName%3Dpayara.payara-vscode%26ssr%3Dfalse%23overview%22"
+              title="Payara Tools marketplace link">Payara Tools for VS Code</a>
+            </div>
+            <div ext="Payara.payara-vscode" displayName="Payara Tools">
+              <a href="#" title="Install Payara Tools extension...">Install Payara Tools</a>
+            </div>
+          </div>
+        </div>
+        <div class="row mb-3">
+          <div class="col">
+            <h3 class="font-weight-light">Help</h3>
+            <div>
+              <a href="command:microprofile.helper.openUrl?%22https%3A%2F%2Fgithub.com%2FMicroShed%2Fvscode-microprofile-pack%2Fissues%22"
+                title="Questions & Issues">Questions & Issues</a>
+            </div>
+          </div>
+        </div>
+        <div class="row">
+          <div class="col">
+            <div class="section-div">
+              <input type="checkbox" class="form-check-input" id="showOnStartup" checked>
+              <label for="showOnStartup">Show overview page on startup.</label>
+            </div>
+          </div>
+        </div>
+      </div>
+</body>
+
+</html>

--- a/src/overview/assets/index.html
+++ b/src/overview/assets/index.html
@@ -34,7 +34,19 @@
             <h3 class="font-weight-light">Documentation</h3>
             <div>
               <a href="command:microprofile.helper.openUrl?%22https%3A%2F%2Fmicroprofile.io%22"
-                title="Learn about MicroProfile">MicroProfile</a>
+                title="Learn about MicroProfile, landing page">Landing Page</a>
+            </div>
+            <div>
+              <a href="command:microprofile.helper.openUrl?%22https%3A%2F%2Fwiki.eclipse.org%2FMicroProfile%2FLearning%5FResources%22"
+                title="Learning Resources">Learning Resources</a>
+            </div>
+            <div>
+              <a href="command:microprofile.helper.openUrl?%22https%3A%2F%2Fmicroprofile.io%2Ffaq%22"
+                title="Frequently Asked Questions">FAQ</a>
+            </div>
+            <div>
+              <a href="command:microprofile.helper.openUrl?%22https%3A%2F%2Fmicroprofile.io%2Fblog%22"
+                title="MicroProfile blog">MicroProfile blog</a>
             </div>
           </div>
         </div>

--- a/src/overview/assets/index.ts
+++ b/src/overview/assets/index.ts
@@ -1,0 +1,70 @@
+/**
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT license.
+ * Adapted from @see https://github.com/microsoft/vscode-java-pack/blob/master/src/overview/assets/index.ts
+ */
+
+import $ = require("jquery");
+import "../../assets/vscode.scss";
+import "bootstrap/js/src/tab";
+import { INSTALL_EXT_COMMAND, SET_SHOW_ON_STARTUP_COMMAND, SYNC_CHECKBOX_VALUE, SYNC_EXT_VISIBILITY } from "../../util/constants";
+
+
+window.addEventListener("message", event => {
+  if (event.data.command === SYNC_EXT_VISIBILITY) {
+    syncExtensionVisibility(event.data.installedExtensions);
+    syncSectionVisibility();
+  } else if (event.data.command === SET_SHOW_ON_STARTUP_COMMAND) {
+    $("#showOnStartup").prop("checked", event.data.visibility);
+  } else if (event.data.command === SYNC_CHECKBOX_VALUE) {
+    syncCheckboxValue(event.data.checkboxValue);
+  }
+});
+
+function syncCheckboxValue(checkboxValue: boolean) {
+  $("#showOnStartup").prop("checked", checkboxValue);
+}
+
+function syncExtensionVisibility(extensions: any) {
+  $("div[ext]").each((index, elem) => {
+    const anchor = $(elem);
+    const ext = (anchor.attr("ext") || "").toLowerCase();
+    if (extensions.indexOf(ext) !== -1) {
+      anchor.hide();
+    } else {
+      anchor.show();
+    }
+  });
+}
+
+function syncSectionVisibility() {
+  $("div h3").parent().each((i, div) => {
+    if (!$(div).children("h3 ~ div").is(":visible")) {
+      $(div).hide();
+    } else {
+      $(div).show();
+    }
+  });
+}
+
+declare function acquireVsCodeApi(): any;
+const vscode = acquireVsCodeApi();
+
+function installExtension(extName: string, displayName: string) {
+  vscode.postMessage({
+    command: INSTALL_EXT_COMMAND,
+    extName: extName,
+    displayName: displayName
+  });
+}
+
+$("#showOnStartup").change(function () {
+  vscode.postMessage({
+    command: SET_SHOW_ON_STARTUP_COMMAND,
+    visibility: $(this).is(":checked")
+  });
+});
+
+$("div[ext]").click(function () {
+  installExtension($(this).attr("ext") || "", $(this).attr("displayName") || "");
+});

--- a/src/overview/overviewPage.ts
+++ b/src/overview/overviewPage.ts
@@ -80,16 +80,16 @@ export class OverviewPage {
     syncExtensionVisibility(this._panelView);
 
     // monitor extensions installed
-    vscode.extensions.onDidChange(e => {
+    this._context.subscriptions.push(vscode.extensions.onDidChange(e => {
       syncExtensionVisibility(this._panelView);
-    });
+    }));
 
     // monitor workspace configuration for alwaysShowOverview setting
-    vscode.workspace.onDidChangeConfiguration((event: vscode.ConfigurationChangeEvent) => {
+    this._context.subscriptions.push(vscode.workspace.onDidChangeConfiguration((event: vscode.ConfigurationChangeEvent) => {
       if (event.affectsConfiguration(MICROPROFILE_SHOW_OVERVIEW_CONFIGURATION)) {
         syncCheckboxValue(this._panelView);
       }
-    });
+    }));
 
     this._context.subscriptions.push(this._panelView.webview.onDidReceiveMessage(async (e) => {
       if (e.command === SET_SHOW_ON_STARTUP_COMMAND) {

--- a/src/overview/overviewPage.ts
+++ b/src/overview/overviewPage.ts
@@ -9,8 +9,6 @@ export class OverviewPage {
 
   private _context: vscode.ExtensionContext;
   private _panelView: vscode.WebviewPanel;
-  private _disposables: vscode.Disposable[];
-
   private static readFile = util.promisify(fsReadFile);
 
   public static showOverview(context: vscode.ExtensionContext) {
@@ -27,7 +25,6 @@ export class OverviewPage {
 
   private constructor (context: vscode.ExtensionContext) {
     this._context = context;
-    this._disposables = [];
     this._panelView = this.createOverviewPage();
     this.initializeOverview();
   }
@@ -49,11 +46,7 @@ export class OverviewPage {
     );
     panel.onDidDispose(() => {
       OverviewPage.currentPanel = undefined;
-      while (this._disposables.length) {
-        this._disposables.pop()?.dispose();
-      }
-      this._disposables.pop
-    }, null);
+    });
 
     return panel;
   }

--- a/src/overview/overviewPage.ts
+++ b/src/overview/overviewPage.ts
@@ -1,0 +1,118 @@
+import * as vscode from "vscode";
+import * as util from "util";
+import { readFile as fsReadFile } from "fs";
+import { INSTALL_EXT_COMMAND, MICROPROFILE_SHOW_OVERVIEW_CONFIGURATION, SET_SHOW_ON_STARTUP_COMMAND, SYNC_CHECKBOX_VALUE, SYNC_EXT_VISIBILITY } from "../util/constants";
+
+export class OverviewPage {
+
+  public static currentPanel: OverviewPage | undefined;
+
+  private _context: vscode.ExtensionContext;
+  private _panelView: vscode.WebviewPanel;
+  private _disposables: vscode.Disposable[];
+
+  private static readFile = util.promisify(fsReadFile);
+
+  public static showOverview(context: vscode.ExtensionContext) {
+    
+    // show overview view if it already exists
+    if (OverviewPage.currentPanel) {
+      OverviewPage.currentPanel._panelView.reveal();
+      return;
+    }
+
+    // create a new overview page if it does not already exist
+    OverviewPage.currentPanel = new OverviewPage(context);
+  }
+
+  private constructor (context: vscode.ExtensionContext) {
+    this._context = context;
+    this._disposables = [];
+    this._panelView = this.createOverviewPage();
+    this.initializeOverview();
+  }
+
+  public createOverviewPage(): vscode.WebviewPanel {
+    // create overview view
+    const panel = vscode.window.createWebviewPanel(
+      "microprofile.overview",
+      "MicroProfile Overview",
+      {
+        viewColumn: vscode.ViewColumn.One,
+        preserveFocus: true
+      },
+      {
+        enableScripts: true,
+        enableCommandUris: true,
+        retainContextWhenHidden: true
+      }
+    );
+    panel.onDidDispose(() => {
+      OverviewPage.currentPanel = undefined;
+      while (this._disposables.length) {
+        this._disposables.pop()?.dispose();
+      }
+      this._disposables.pop
+    }, null);
+
+    return panel;
+  }
+
+  private async initializeOverview() {
+    const resourceUri = this._context.asAbsolutePath("./out/assets/overview/index.html");
+    this._panelView.webview.html = await OverviewPage.loadTextFromFile(resourceUri);
+
+    // ensures checkbox value matches the corresponding alwaysShowOverview setting
+    function syncCheckboxValue(webviewPanel: vscode.WebviewPanel) {
+      let checkboxValue = vscode.workspace.getConfiguration().get<boolean>(MICROPROFILE_SHOW_OVERVIEW_CONFIGURATION);
+      if (checkboxValue !== undefined) {
+        webviewPanel.webview.postMessage({
+          command: SYNC_CHECKBOX_VALUE,
+          checkboxValue: checkboxValue
+        })
+      }
+    }
+
+    // ensures prompt to install extensions displayed in overview page are only shown
+    // if they are not installed
+    function syncExtensionVisibility(webviewPanel: vscode.WebviewPanel) {
+      const installedExtensions = vscode.extensions.all.map(ext => ext.id.toLowerCase());
+      webviewPanel.webview.postMessage({
+        command: SYNC_EXT_VISIBILITY,
+        installedExtensions: installedExtensions
+      });
+    }
+
+    syncCheckboxValue(this._panelView);
+    syncExtensionVisibility(this._panelView);
+
+    // monitor extensions installed
+    vscode.extensions.onDidChange(e => {
+      syncExtensionVisibility(this._panelView);
+    });
+
+    // monitor workspace configuration for alwaysShowOverview setting
+    vscode.workspace.onDidChangeConfiguration((event: vscode.ConfigurationChangeEvent) => {
+      if (event.affectsConfiguration(MICROPROFILE_SHOW_OVERVIEW_CONFIGURATION)) {
+        syncCheckboxValue(this._panelView);
+      }
+    });
+
+    this._context.subscriptions.push(this._panelView.webview.onDidReceiveMessage(async (e) => {
+      if (e.command === SET_SHOW_ON_STARTUP_COMMAND) {
+        // set configuration value
+        vscode.workspace.getConfiguration().update(MICROPROFILE_SHOW_OVERVIEW_CONFIGURATION, e.visibility, vscode.ConfigurationTarget.Global);
+      }
+      if (e.command === INSTALL_EXT_COMMAND) {
+        await vscode.commands.executeCommand("microprofile.helper.installExtension", e.extName);
+      }
+    }));
+  }
+
+  private static async loadTextFromFile(resourceUri: string) {
+    let buffer = await this.readFile(resourceUri);
+    return buffer.toString();
+  }
+
+}
+

--- a/src/util/commands.ts
+++ b/src/util/commands.ts
@@ -1,0 +1,62 @@
+import * as vscode from "vscode";
+
+/**
+ * Check if MicroProfile Starter has been installed, if it has
+ * execute the MicroProfile Starter command. If it is not installed,
+ * prompt user to install.
+ * 
+ * @param context vscode extension context
+ */
+export async function createMicroProfileStarterProjectCmdHandler(context: vscode.ExtensionContext) {
+    if (!await validateAndRecommendExtension("microProfile-community.mp-starter-vscode-ext", "MicroProfile Starter for Visual Studio Code is recommended to generate starter projects for Eclipse MicroProfile.", true)) {
+        return;
+    }
+    await vscode.commands.executeCommand("extension.microProfileStarter");
+}
+
+/**
+ * Check if MicroProfile REST Client Generator has been installed, if it has
+ * execute the Generate a REST Client command. If it is not installed,
+ * prompt user to install.
+ * 
+ * @param context vscode extension context
+ */
+export async function generateMicroProfileRESTClient(context: vscode.ExtensionContext) {
+    if (!await validateAndRecommendExtension("microProfile-community.mp-rest-client-generator-vscode-ext", "MicroProfile REST Client Generator for Visual Studio Code is recommended to generate MicroProfile REST Client Interface template.", true)) {
+        return;
+    }
+    await vscode.commands.executeCommand("microprofile.restclient.generate");
+}
+
+export async function installExtension(context: vscode.ExtensionContext, extensionName: string) {
+    return vscode.window.withProgress({ location: vscode.ProgressLocation.Notification, title: `Installing ${extensionName}...` }, progress => {
+        return vscode.commands.executeCommand("workbench.extensions.installExtension", extensionName);
+    }).then(() => {
+        vscode.window.showInformationMessage(`Successfully installed ${extensionName}.`);
+    });
+}
+
+export async function openUrl(context: vscode.ExtensionContext, url: string) {
+    vscode.commands.executeCommand("vscode.open", vscode.Uri.parse(url));
+}
+
+async function validateAndRecommendExtension(extName: string, message: string, isForce: boolean = false) {
+    if (isExtensionInstalled(extName)) {
+        return true;
+    }
+
+    await recommendExtension(extName, message);
+    return false;
+}
+
+function isExtensionInstalled(extName: string) {
+    return !!vscode.extensions.getExtension(extName);
+}
+
+async function recommendExtension(extName: string, message: string): Promise<void> {
+    const action = "Install";
+    const answer = await vscode.window.showInformationMessage(message, action);
+    if (answer === action) {
+        await vscode.commands.executeCommand("microprofile.helper.installExtension", extName, extName);
+    }
+}

--- a/src/util/constants.ts
+++ b/src/util/constants.ts
@@ -1,0 +1,6 @@
+export const MICROPROFILE_SHOW_OVERVIEW_CONFIGURATION = "microprofile.alwaysShowOverview";
+
+export const SET_SHOW_ON_STARTUP_COMMAND = "setShowOnStartup";
+export const INSTALL_EXT_COMMAND = "installExtension";
+export const SYNC_CHECKBOX_VALUE = "syncCheckboxValue";
+export const SYNC_EXT_VISIBILITY = "syncExtensionVisibility";

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,28 @@
+{
+    "compilerOptions": {
+      "baseUrl": ".",
+      "paths": { "*": ["types/*"] },
+        "module": "commonjs",
+        "target": "es6",
+        "outDir": "out",
+        "lib": [
+            "es6",
+            "dom"
+        ],
+        "sourceMap": true,
+        "rootDir": "src",
+        /* Strict Type-Checking Option */
+        "strict": true,   /* enable all strict type-checking options */
+        /* Additional Checks */
+        "noUnusedLocals": true, /* Report errors on unused locals. */
+        // "noImplicitReturns": true, /* Report error when not all code paths in function return a value. */
+        // "noFallthroughCasesInSwitch": true, /* Report errors for fallthrough cases in switch statement. */
+        // "noUnusedParameters": true,  /* Report errors on unused parameters. */
+        "jsx": "react"
+    },
+    "exclude": [
+        "node_modules",
+        ".vscode-test",
+        "**/assets",
+    ]
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,0 +1,92 @@
+/**
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT license.
+ * @see https://github.com/microsoft/vscode-java-pack/blob/master/webpack.config.js
+ */
+const HtmlWebpackPlugin = require('html-webpack-plugin');
+const HtmlWebpackInlineSourcePlugin = require('html-webpack-inline-source-plugin');
+const path = require('path');
+
+module.exports = function (env, argv) {
+  env = env || {};
+
+  return [{
+    name: 'assets',
+    mode: 'none',
+    entry: {
+      overview: './src/overview/assets/index.ts'
+    },
+    module: {
+      rules: [{
+        test: /\.ts(x?)$/,
+        exclude: /node_modules/,
+        use: 'ts-loader'
+      }, {
+        test: /\.(scss)$/,
+        use: [{
+          loader: 'style-loader'
+        }, {
+          loader: 'css-loader'
+        }, {
+          loader: 'postcss-loader',
+          options: {
+            plugins: function () {
+              return [require('autoprefixer')];
+            }
+          }
+        }, {
+          loader: 'sass-loader'
+        }]
+      }]
+    },
+    output: {
+      filename: 'assets/[name]/index.js',
+      path: path.resolve(__dirname, 'out'),
+      publicPath: '/',
+      devtoolModuleFilenameTemplate: "../[resource-path]"
+    },
+    plugins: [
+      new HtmlWebpackPlugin({
+        filename: path.resolve(__dirname, 'out/assets/overview/index.html'),
+        template: 'src/overview/assets/index.html',
+        inlineSource: '.(js|css)$',
+        chunks: ['overview']
+      }),
+      new HtmlWebpackInlineSourcePlugin(),
+    ],
+    devtool: 'source-map',
+    resolve: {
+      extensions: ['.js', '.ts', '.tsx']
+    }
+  }, {
+    name: 'extension',
+    target: 'node',
+    mode: 'none',
+    entry: {
+      extension: './src/extension.ts'
+    },
+    module: {
+      rules: [{
+        test: /\.ts$/,
+        exclude: /node_modules/,
+        use: 'ts-loader'
+      }]
+    },
+    resolve: {
+      modules: ['node_modules', path.resolve(__dirname, 'src')],
+      mainFiles: ['index'],
+      extensions: ['.js', '.ts', '.json']
+    },
+    output: {
+      filename: '[name].js',
+      path: path.resolve(__dirname, 'out'),
+      libraryTarget: "commonjs2",
+      publicPath: '/',
+      devtoolModuleFilenameTemplate: "../[resource-path]"
+    },
+    externals: {
+      vscode: 'commonjs vscode'
+    },
+    devtool: 'source-map'
+  }]
+};


### PR DESCRIPTION
Removes runtime specific extensions from the extension pack and instead recommends them through the new Overview page.

This is how the Overview page will look on installation.

- Selecting either of the commands under the "Start" section will execute the corresponding starter command, ie. selecting "Create a MicroProfile project..." will first check that the MP Starter extension is installed (if not, will prompt user to install) and then call the `extension.microprofileStarter` command.
- "MicroProfile" under "Documentation" links to https://microprofile.io/
- "MicroProfile Runtimes" includes links to runtime specific VS Code extensions, as well as prompts to install each extension.
- "Questions & Issues" under "Help" links to https://github.com/MicroShed/vscode-microprofile-pack/issues

<img src= https://user-images.githubusercontent.com/26146482/94702439-c0da7d00-030b-11eb-9398-1eced3495dec.png width="50%" height="50%">

If a user installs a runtime specific extension (ie. Open Liberty Tools is installed), the corresponding "Install ..." prompt will no longer appear in the overview page. 

<img src=https://user-images.githubusercontent.com/26146482/94702449-c59f3100-030b-11eb-8b00-1d72335cbd03.png width="50%" height="50%">

If for any reason, one of the extensions included in the extension pack is uninstalled, the Overview page will have a new section titled "Extensions" that will prompt the user to re-install the corresponding extension.

<img src=https://user-images.githubusercontent.com/26146482/94702463-cb951200-030b-11eb-8a74-36bd2be714e1.png width="50%" height="50%">

Fixes #9 
Signed-off-by: Kathryn Kodama <kathryn.s.kodama@gmail.com>